### PR TITLE
Local storage queue sync and query queue

### DIFF
--- a/client/bundles/Main/components/Game.jsx
+++ b/client/bundles/Main/components/Game.jsx
@@ -1,61 +1,28 @@
 import React, { useState } from 'react'
-import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query'
-import { getQuote, getQuotes } from '../services/quoteService'
+import { useQueryClient } from '@tanstack/react-query'
 import Author from './Author'
 import Quotes from './Quotes'
 import ProgressQueueBtn from './ProgressQueueBtn'
 import useWindowDimensions from '../../layoutUtils/useWindowDimensions'
+
+import { initializeQuoteQueue } from '../queries/initializeQuoteQueue'
 import {
-  setLocalStorageQueue,
-  getLocalStorageQueue,
-} from '../services/localStorage'
+  addQuoteToQueue,
+  progressQueuesAndAddQuote,
+} from '../mutations/addQuote'
 
 const Game = () => {
   const queryClient = useQueryClient()
   const [randomizer, setRandomizer] = useState(Math.random())
   const [guessed, setGuessed] = useState(false)
   const { width: windowWidth } = useWindowDimensions()
-  // prime the quote queue with 3 payloads before rendering component
-  // todo revise to dedicated endpoint once client is a bit more formed
 
-  // return local storage, if none fetches three quotes to prime the queue
-  // TODO suspense for initial hard fetch experience
-  const { data: quoteQueue, status } = useQuery({
-    queryKey: ['quote-queue'],
-    queryFn: getQuotes,
-    initialData: getLocalStorageQueue(),
-    staleTime: Infinity,
-  })
-
-  // mutation that concats a quote to the quote without progression
-  const { mutate: addQuote } = useMutation({
-    mutationFn: getQuote,
-    onSuccess: (newQuote) => addQuoteToQueues(newQuote),
-  })
-
-  // mutation that progresses both queues, fetches 1 quote, and calls the queue length monitor
-  const { mutate: progressQuoteQueue } = useMutation({
-    mutationFn: getQuote,
-    onMutate: () =>
-      queryClient.setQueryData(['quote-queue'], ([_, ...rest]) => rest),
-    onSuccess: (newQuote) => addQuoteToQueues(newQuote),
-    onSettled: () => monitorQueueLength(addQuote),
-  })
-
-  const addQuoteToQueues = (newQuote) => {
-    queryClient.setQueryData(['quote-queue'], (existingQueue) => {
-      const newQueue = existingQueue.concat(newQuote)
-      setLocalStorageQueue(newQueue)
-      return newQueue
-    })
-  }
-
-  const monitorQueueLength = () => {
-    const queueLength = queryClient.getQueryData(['quote-queue']).length
-    if (queueLength < 5) {
-      addQuote()
-    }
-  }
+  const { data: quoteQueue, status } = initializeQuoteQueue()
+  const { mutate: addQuote } = addQuoteToQueue(queryClient)
+  const { mutate: progressQuoteQueue } = progressQueuesAndAddQuote(
+    addQuote,
+    queryClient
+  )
 
   const handleProgressQueue = () => {
     setRandomizer(Math.random())

--- a/client/bundles/Main/components/Main.jsx
+++ b/client/bundles/Main/components/Main.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+
 import Game from './Game'
 
 const queryClient = new QueryClient()
@@ -7,6 +9,7 @@ const queryClient = new QueryClient()
 const Main = () => (
   <QueryClientProvider client={queryClient}>
     <Game />
+    <ReactQueryDevtools initialIsOpen={false} />
   </QueryClientProvider>
 )
 

--- a/client/bundles/Main/components/Quotes.jsx
+++ b/client/bundles/Main/components/Quotes.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
 import { postScore } from '../services/scoreService'
 import Quote from './Quote'
+import { useQueryClient } from '@tanstack/react-query'
+import { setLocalStorageQueue } from './Game'
+import { progressLocalStorageQueue } from '../services/localStorage'
 
 const Quotes = ({ quote, falseQuote, guessed, setGuessed, randomizer }) => {
+  const queryClient = useQueryClient()
+
   const isCorrect = (idx) =>
     (randomizer >= 0.5 && idx === 1) || (randomizer < 0.5 && idx === 0)
   const quotesArr =
@@ -15,6 +20,7 @@ const Quotes = ({ quote, falseQuote, guessed, setGuessed, randomizer }) => {
   const handleClick = async (idx) => {
     setGuessed(true)
     postScore(isCorrect(idx))
+    progressLocalStorageQueue(queryClient)
   }
 
   return (

--- a/client/bundles/Main/mutations/addQuote.js
+++ b/client/bundles/Main/mutations/addQuote.js
@@ -1,0 +1,23 @@
+import { useMutation } from '@tanstack/react-query'
+import {
+  addQuoteToQueues,
+  monitorQueueLength,
+  progressQueryQueue,
+} from './helpers'
+import { getQuote } from '../services/quoteService'
+
+export const addQuoteToQueue = (queryClient) => {
+  return useMutation({
+    mutationFn: getQuote,
+    onSuccess: (newQuote) => addQuoteToQueues(newQuote, queryClient),
+  })
+}
+
+export const progressQueuesAndAddQuote = (addQuote, queryClient) => {
+  return useMutation({
+    mutationFn: getQuote,
+    onMutate: () => progressQueryQueue(queryClient),
+    onSuccess: (newQuote) => addQuoteToQueues(newQuote, queryClient),
+    onSettled: () => monitorQueueLength(addQuote, queryClient),
+  })
+}

--- a/client/bundles/Main/mutations/helpers.js
+++ b/client/bundles/Main/mutations/helpers.js
@@ -1,0 +1,21 @@
+import { setLocalStorageQueue } from '../services/localStorage'
+
+export const addQuoteToQueues = (newQuote, queryClient) => {
+  queryClient.setQueryData(['quote-queue'], (existingQueue) => {
+    const newQueue = existingQueue.concat(newQuote)
+    setLocalStorageQueue(newQueue)
+    return newQueue
+  })
+}
+
+export const monitorQueueLength = (addQuote, queryClient) => {
+  const queueLength = queryClient.getQueryData(['quote-queue']).length
+
+  if (queueLength < 4) {
+    addQuote()
+  }
+}
+
+export const progressQueryQueue = (queryClient) => {
+  queryClient.setQueryData(['quote-queue'], ([_, ...rest]) => rest)
+}

--- a/client/bundles/Main/queries/initializeQuoteQueue.js
+++ b/client/bundles/Main/queries/initializeQuoteQueue.js
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query'
+import { getQuotes } from '../services/quoteService'
+import { getLocalStorageQueue } from '../services/localStorage'
+
+// return local storage, if none fetches three quotes to prime the queue
+
+export const initializeQuoteQueue = () => {
+  return useQuery({
+    queryKey: ['quote-queue'],
+    queryFn: getQuotes,
+    initialData: getLocalStorageQueue(),
+    staleTime: Infinity,
+  })
+}

--- a/client/bundles/Main/services/localStorage.js
+++ b/client/bundles/Main/services/localStorage.js
@@ -1,0 +1,19 @@
+export const setLocalStorageQueue = (quoteQueue) => {
+  return localStorage.setItem('quote-queue', JSON.stringify(quoteQueue))
+}
+
+export const getLocalStorageQueue = () => {
+  const queue = localStorage.getItem('quote-queue')
+  if (queue) {
+    return JSON.parse(queue)
+  }
+}
+
+export const progressLocalStorageQueue = (queryClient) => {
+  const existingQueue = queryClient.getQueryData(['quote-queue'])
+
+  if (existingQueue) {
+    const [a, ...rest] = existingQueue
+    return setLocalStorageQueue(rest)
+  }
+}

--- a/client/bundles/Main/services/quoteService.js
+++ b/client/bundles/Main/services/quoteService.js
@@ -13,7 +13,7 @@ export const getQuote = async () => {
 export const getQuotes = async () => {
   const quotes = []
 
-  for (let i = 0; i < 3; i++) {
+  for (let i = 0; i < 2; i++) {
     const data = await getQuote()
     quotes.push(data)
   }


### PR DESCRIPTION
here we have established this pattern for fetching and caching quote payloads

init - Check local storage and return cached payloads, if none fetch 2 quotes to prime the queue, 

mutate - progress the cache queue to return the next payload, on success sync local storage, on settled call monitor queue. 

monitor queue - if queryData.length is below 4, fetch quote and add to queues without progressing the query data. 